### PR TITLE
feat: Post forward

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"hasInstallScript": true,
 			"dependencies": {
 				"@clerk/nextjs": "^4.11.14",
-				"@prisma/client": "^4.11.0",
+				"@prisma/client": "^4.14.1",
 				"@tanstack/react-query": "^4.28.0",
 				"@trpc/client": "^10.18.0",
 				"@trpc/next": "^10.18.0",
@@ -44,7 +44,7 @@
 				"postcss": "^8.4.21",
 				"prettier": "^2.8.7",
 				"prettier-plugin-tailwindcss": "^0.2.7",
-				"prisma": "^4.11.0",
+				"prisma": "^4.14.1",
 				"tailwindcss": "^3.2.7",
 				"typescript": "^5.0.2"
 			}
@@ -580,12 +580,12 @@
 			}
 		},
 		"node_modules/@prisma/client": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.11.0.tgz",
-			"integrity": "sha512-0INHYkQIqgAjrt7NzhYpeDQi8x3Nvylc2uDngKyFDDj1tTRQ4uV1HnVmd1sQEraeVAN63SOK0dgCKQHlvjL0KA==",
+			"version": "4.14.1",
+			"resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.14.1.tgz",
+			"integrity": "sha512-TZIswkeX1ccsHG/eN2kICzg/csXll0osK3EHu1QKd8VJ3XLcXozbNELKkCNfsCUvKJAwPdDtFCzF+O+raIVldw==",
 			"hasInstallScript": true,
 			"dependencies": {
-				"@prisma/engines-version": "4.11.0-57.8fde8fef4033376662cad983758335009d522acb"
+				"@prisma/engines-version": "4.14.0-67.d9a4c5988f480fa576d43970d5a23641aa77bc9c"
 			},
 			"engines": {
 				"node": ">=14.17"
@@ -600,16 +600,16 @@
 			}
 		},
 		"node_modules/@prisma/engines": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.11.0.tgz",
-			"integrity": "sha512-0AEBi2HXGV02cf6ASsBPhfsVIbVSDC9nbQed4iiY5eHttW9ZtMxHThuKZE1pnESbr8HRdgmFSa/Kn4OSNYuibg==",
+			"version": "4.14.1",
+			"resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.14.1.tgz",
+			"integrity": "sha512-APqFddPVHYmWNKqc+5J5SqrLFfOghKOLZxobmguDUacxOwdEutLsbXPVhNnpFDmuQWQFbXmrTTPoRrrF6B1MWA==",
 			"devOptional": true,
 			"hasInstallScript": true
 		},
 		"node_modules/@prisma/engines-version": {
-			"version": "4.11.0-57.8fde8fef4033376662cad983758335009d522acb",
-			"resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.11.0-57.8fde8fef4033376662cad983758335009d522acb.tgz",
-			"integrity": "sha512-3Vd8Qq06d5xD8Ch5WauWcUUrsVPdMC6Ge8ILji8RFfyhUpqon6qSyGM0apvr1O8n8qH8cKkEFqRPsYjuz5r83g=="
+			"version": "4.14.0-67.d9a4c5988f480fa576d43970d5a23641aa77bc9c",
+			"resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.14.0-67.d9a4c5988f480fa576d43970d5a23641aa77bc9c.tgz",
+			"integrity": "sha512-3jum8/YSudeSN0zGW5qkpz+wAN2V/NYCQ+BPjvHYDfWatLWlQkqy99toX0GysDeaUoBIJg1vaz2yKqiA3CFcQw=="
 		},
 		"node_modules/@rushstack/eslint-patch": {
 			"version": "1.2.0",
@@ -4323,13 +4323,13 @@
 			}
 		},
 		"node_modules/prisma": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/prisma/-/prisma-4.11.0.tgz",
-			"integrity": "sha512-4zZmBXssPUEiX+GeL0MUq/Yyie4ltiKmGu7jCJFnYMamNrrulTBc+D+QwAQSJ01tyzeGHlD13kOnqPwRipnlNw==",
+			"version": "4.14.1",
+			"resolved": "https://registry.npmjs.org/prisma/-/prisma-4.14.1.tgz",
+			"integrity": "sha512-z6hxzTMYqT9SIKlzD08dhzsLUpxjFKKsLpp5/kBDnSqiOjtUyyl/dC5tzxLcOa3jkEHQ8+RpB/fE3w8bgNP51g==",
 			"devOptional": true,
 			"hasInstallScript": true,
 			"dependencies": {
-				"@prisma/engines": "4.11.0"
+				"@prisma/engines": "4.14.1"
 			},
 			"bin": {
 				"prisma": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 	},
 	"dependencies": {
 		"@clerk/nextjs": "^4.11.14",
-		"@prisma/client": "^4.11.0",
+		"@prisma/client": "^4.14.1",
 		"@tanstack/react-query": "^4.28.0",
 		"@trpc/client": "^10.18.0",
 		"@trpc/next": "^10.18.0",
@@ -46,7 +46,7 @@
 		"postcss": "^8.4.21",
 		"prettier": "^2.8.7",
 		"prettier-plugin-tailwindcss": "^0.2.7",
-		"prisma": "^4.11.0",
+		"prisma": "^4.14.1",
 		"tailwindcss": "^3.2.7",
 		"typescript": "^5.0.2"
 	},

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,3 +38,9 @@ model UserLikePost {
     
     @@index([userId,postId])
 }
+
+model UserPostForward {
+    id          Int     @id @default(autoincrement())
+    userId      String  @db.VarChar(32)
+    postId      String  @db.VarChar(32)
+}

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -4,8 +4,17 @@ import { OptionDots } from "./Icons/OptionDots"
 import { ExternalLink } from "./Icons/ExternalLink"
 import { Calendar } from "./Icons/Calendar"
 import { Chat } from "./Icons/Chat"
+import { PostForward } from "./Icons/PostForward"
+import { Quote } from "./Icons/Quote"
 
-export type IconKindProps = "trash" | "optionDots" | "externalLink" | "calendar" | "chat"
+export type IconKindProps =
+	| "trash"
+	| "postForward"
+	| "quote"
+	| "optionDots"
+	| "externalLink"
+	| "calendar"
+	| "chat"
 
 const GetIconByType = (kind: IconKindProps) => {
 	switch (kind) {
@@ -19,6 +28,10 @@ const GetIconByType = (kind: IconKindProps) => {
 			return <Calendar />
 		case "chat":
 			return <Chat />
+		case "postForward":
+			return <PostForward />
+		case "quote":
+			return <Quote />
 		default:
 			return null
 	}

--- a/src/components/Icons/Heart.tsx
+++ b/src/components/Icons/Heart.tsx
@@ -5,12 +5,14 @@ type HtmlSvgProps = InputHTMLAttributes<SVGSVGElement> & {
 }
 
 export const Heart = (props: HtmlSvgProps) => {
+	//const propsWithoutFillColor = { ...(({ fillColor, ...o }) => o)(props) }
+	const { fillColor, ...propsWithoutFillColor } = props
 	return (
 		<svg
 			className=""
 			viewBox="0 0 1024 1024"
 			fill={props.fillColor}
-			{...props}
+			{...propsWithoutFillColor}
 			version="1.1"
 			xmlns="http://www.w3.org/2000/svg"
 		>

--- a/src/components/Icons/PostForward.tsx
+++ b/src/components/Icons/PostForward.tsx
@@ -1,0 +1,12 @@
+import Image from "next/image"
+
+export const PostForward = () => {
+	return (
+		<Image
+			alt="Post Forward"
+			src={"https://cdn.jsdelivr.net/npm/heroicons@1.0.1/outline/document-duplicate.svg"}
+			width={24}
+			height={24}
+		/>
+	)
+}

--- a/src/components/Icons/Quote.tsx
+++ b/src/components/Icons/Quote.tsx
@@ -1,0 +1,12 @@
+import Image from "next/image"
+
+export const Quote = () => {
+	return (
+		<Image
+			alt="Post Forward"
+			src={"https://cdn.jsdelivr.net/npm/heroicons@1.0.1/outline/pencil-alt.svg"}
+			width={24}
+			height={24}
+		/>
+	)
+}

--- a/src/components/postsPage/FetchPosts.tsx
+++ b/src/components/postsPage/FetchPosts.tsx
@@ -15,6 +15,9 @@ export const FetchPosts: FC<{
 	signInUser: SignInUser
 	isUserFollowProfile: boolean | null
 }> = ({ userId, isUserFollowProfile, signInUser }) => {
+	const router = useRouter()
+	const type = usePostMenuItemsType(isUserFollowProfile, signInUser, userId)
+
 	const forwardedPostIdsByUser = api.posts.getPostIdsForwardedByUser.useQuery()
 	const getPosts = api.posts.getAllByAuthorId.useQuery(userId)
 	const [posts, setPosts] = useState<PostWithUser[]>()
@@ -34,10 +37,6 @@ export const FetchPosts: FC<{
 			}
 		}
 	}, [getPosts.data, forwardedPostIdsByUser.data])
-
-	const router = useRouter()
-
-	const type = usePostMenuItemsType(isUserFollowProfile, signInUser, userId)
 
 	const deletePost = api.posts.deletePost.useMutation({
 		onSuccess: async () => {
@@ -180,7 +179,6 @@ export const FetchPosts: FC<{
 					}}
 					menuItemsType={type}
 					onOptionClick={handlePostOptionClick}
-					isForwardedByUser={postsWithUser.post.isForwardedPostBySignInUser}
 					forwardAction={(forward, postId) => {
 						if (forward === "deleteForward") {
 							removePostForward.mutate(postId)

--- a/src/components/postsPage/FetchPosts.tsx
+++ b/src/components/postsPage/FetchPosts.tsx
@@ -1,4 +1,4 @@
-import { type FC } from "react"
+import { useEffect, type FC, useState } from "react"
 import { api } from "~/utils/api"
 import { LoadingPage } from "../LoadingPage"
 import { PostItem } from "./PostItem"
@@ -8,19 +8,33 @@ import { type SignInUser } from "../profilePage/types"
 import { ParseZodErrorToString } from "~/utils/helpers"
 import { usePostMenuItemsType } from "~/hooks/usePostMenuItemsType"
 import { CONFIG } from "~/config"
+import { PostWithUser } from "./types"
 
 export const FetchPosts: FC<{
 	userId: string
 	signInUser: SignInUser
 	isUserFollowProfile: boolean | null
 }> = ({ userId, isUserFollowProfile, signInUser }) => {
-	const posts = api.posts.getAllByAuthorId.useQuery(userId)
+	const forwardedPostIdsByUser = api.posts.getPostIdsForwardedByUser.useQuery()
+	const getPosts = api.posts.getAllByAuthorId.useQuery(userId)
+	const [posts, setPosts] = useState<PostWithUser[]>()
+	const [usagePostId, setUsagePostId] = useState<string | null>()
 
-	const postsLikedByUser = api.posts.getPostsLikedByUser.useQuery(
-		posts.data?.map((postAuthor) => {
-			return postAuthor.post.id
-		})
-	)
+	useEffect(() => {
+		if (getPosts.data) {
+			if (forwardedPostIdsByUser.data) {
+				const posts = getPosts.data.map((post) => {
+					post.post.isForwardedPostBySignInUser = forwardedPostIdsByUser.data.some(
+						(postId) => postId === post.post.id
+					)
+					return post
+				})
+				setPosts(posts)
+			} else {
+				setPosts(getPosts.data)
+			}
+		}
+	}, [getPosts.data])
 
 	const router = useRouter()
 
@@ -29,7 +43,7 @@ export const FetchPosts: FC<{
 	const deletePost = api.posts.deletePost.useMutation({
 		onSuccess: async () => {
 			toast.success("Post Deleted!")
-			await posts.refetch()
+			await getPosts.refetch()
 		},
 		onError: (e) => {
 			const error =
@@ -59,7 +73,100 @@ export const FetchPosts: FC<{
 		}
 	}
 
-	if (posts.isLoading) {
+	const likePost = api.posts.setPostLiked.useMutation({
+		onSuccess: () => {
+			toast.success("Post Liked!")
+			if (posts) {
+				const copyPosts = posts?.map((post) => {
+					if (post.post.id === usagePostId) {
+						post.post.likeCount += 1
+						post.post.isLikedBySignInUser = true
+					}
+					return post
+				})
+				setPosts(copyPosts)
+			}
+			setUsagePostId(null)
+		},
+		onError: (e) => {
+			const error =
+				ParseZodErrorToString(e.data?.zodError) ??
+				"Failed to like post! Please try again later"
+			toast.error(error, { duration: CONFIG.TOAST_ERROR_DURATION_MS })
+		},
+	})
+
+	const unlikePost = api.posts.setPostUnliked.useMutation({
+		onSuccess: () => {
+			toast.success("Post Unliked!")
+			if (posts) {
+				const copyPosts = posts?.map((post) => {
+					if (post.post.id === usagePostId) {
+						post.post.likeCount -= 1
+						post.post.isLikedBySignInUser = false
+					}
+					return post
+				})
+				setPosts(copyPosts)
+			}
+			setUsagePostId(null)
+		},
+		onError: (e) => {
+			const error =
+				ParseZodErrorToString(e.data?.zodError) ??
+				"Failed to unlike post! Please try again later"
+			toast.error(error, { duration: CONFIG.TOAST_ERROR_DURATION_MS })
+		},
+	})
+
+	const forwardPost = api.posts.forwardPost.useMutation({
+		onSuccess: () => {
+			toast.success("Post Forwarded!")
+			if (posts) {
+				const copyPosts = posts?.map((post) => {
+					if (post.post.id === usagePostId) {
+						post.post.forwardsCount += 1
+						post.post.isForwardedPostBySignInUser = true
+					}
+					return post
+				})
+				setPosts(copyPosts)
+			}
+			setUsagePostId(null)
+		},
+		onError: (e) => {
+			const error =
+				ParseZodErrorToString(e.data?.zodError) ??
+				"Failed to forward post! Please try again later"
+			toast.error(error, { duration: CONFIG.TOAST_ERROR_DURATION_MS })
+		},
+	})
+
+	const removePostForward = api.posts.removePostForward.useMutation({
+		onSuccess: async () => {
+			toast.success("Delete Post Forward!")
+			await getPosts.refetch()
+			if (posts) {
+				const copyPosts = posts?.map((post) => {
+					if (post.post.id === usagePostId) {
+						post.post.forwardsCount -= 1
+						post.post.isForwardedPostBySignInUser = false
+					}
+					return post
+				})
+				setPosts(copyPosts)
+			}
+			setUsagePostId(null)
+		},
+		onError: (e) => {
+			const error =
+				ParseZodErrorToString(e.data?.zodError) ??
+				"Failed to delete forward! Please try again later"
+			toast.error(error, { duration: CONFIG.TOAST_ERROR_DURATION_MS })
+		},
+	})
+
+	if (getPosts.isLoading) {
 		return (
 			<div className="relative">
 				<LoadingPage />
@@ -69,7 +176,7 @@ export const FetchPosts: FC<{
 
 	return (
 		<ul className="">
-			{posts.data?.map((postsWithUser) => (
+			{posts?.map((postsWithUser) => (
 				<PostItem
 					key={postsWithUser.post.id}
 					postWithUser={postsWithUser}
@@ -78,13 +185,23 @@ export const FetchPosts: FC<{
 					}}
 					menuItemsType={type}
 					onOptionClick={handlePostOptionClick}
-					postLiked={
-						postsLikedByUser.data
-							? postsLikedByUser.data.some(
-									(postId) => postId === postsWithUser.post.id
-							  )
-							: false
-					}
+					isForwardedByUser={postsWithUser.post.isForwardedPostBySignInUser}
+					forwardAction={(forward, postId) => {
+						setUsagePostId(postId)
+						if (forward === "deleteForward") {
+							removePostForward.mutate(postId)
+						} else {
+							forwardPost.mutate(postId)
+						}
+					}}
+					likeAction={(action, postId) => {
+						setUsagePostId(postId)
+						if (action === "like") {
+							likePost.mutate(postId)
+						} else {
+							unlikePost.mutate(postId)
+						}
+					}}
 				/>
 			))}
 		</ul>

--- a/src/components/postsPage/FetchPosts.tsx
+++ b/src/components/postsPage/FetchPosts.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type FC, useState } from "react"
+import { type FC, useEffect, useState } from "react"
 import { api } from "~/utils/api"
 import { LoadingPage } from "../LoadingPage"
 import { PostItem } from "./PostItem"
@@ -8,7 +8,7 @@ import { type SignInUser } from "../profilePage/types"
 import { ParseZodErrorToString } from "~/utils/helpers"
 import { usePostMenuItemsType } from "~/hooks/usePostMenuItemsType"
 import { CONFIG } from "~/config"
-import { PostWithUser } from "./types"
+import { type PostWithUser } from "./types"
 
 export const FetchPosts: FC<{
 	userId: string
@@ -34,7 +34,7 @@ export const FetchPosts: FC<{
 				setPosts(getPosts.data)
 			}
 		}
-	}, [getPosts.data])
+	}, [getPosts.data, forwardedPostIdsByUser.data])
 
 	const router = useRouter()
 

--- a/src/components/postsPage/FetchPosts.tsx
+++ b/src/components/postsPage/FetchPosts.tsx
@@ -77,7 +77,7 @@ export const FetchPosts: FC<{
 		onSuccess: () => {
 			toast.success("Post Liked!")
 			if (posts) {
-				const copyPosts = posts?.map((post) => {
+				const copyPosts = posts.map((post) => {
 					if (post.post.id === usagePostId) {
 						post.post.likeCount += 1
 						post.post.isLikedBySignInUser = true
@@ -100,7 +100,7 @@ export const FetchPosts: FC<{
 		onSuccess: () => {
 			toast.success("Post Unliked!")
 			if (posts) {
-				const copyPosts = posts?.map((post) => {
+				const copyPosts = posts.map((post) => {
 					if (post.post.id === usagePostId) {
 						post.post.likeCount -= 1
 						post.post.isLikedBySignInUser = false
@@ -123,7 +123,7 @@ export const FetchPosts: FC<{
 		onSuccess: () => {
 			toast.success("Post Forwarded!")
 			if (posts) {
-				const copyPosts = posts?.map((post) => {
+				const copyPosts = posts.map((post) => {
 					if (post.post.id === usagePostId) {
 						post.post.forwardsCount += 1
 						post.post.isForwardedPostBySignInUser = true
@@ -147,7 +147,7 @@ export const FetchPosts: FC<{
 			toast.success("Delete Post Forward!")
 			await getPosts.refetch()
 			if (posts) {
-				const copyPosts = posts?.map((post) => {
+				const copyPosts = posts.map((post) => {
 					if (post.post.id === usagePostId) {
 						post.post.forwardsCount -= 1
 						post.post.isForwardedPostBySignInUser = false

--- a/src/components/postsPage/PostFooter.tsx
+++ b/src/components/postsPage/PostFooter.tsx
@@ -1,82 +1,16 @@
-import { type FC, useState } from "react"
+import { type FC } from "react"
 import { Icon } from "../Icon"
 import { Heart } from "../Icons/Heart"
 import Link from "next/link"
 import { type PostWithUser } from "./types"
-import { api } from "~/utils/api"
-import toast from "react-hot-toast"
-import { ParseZodErrorToString } from "~/utils/helpers"
-import { CONFIG } from "~/config"
 
 export const PostFooter: FC<{
 	isLikedByUser: boolean
 	isForwardedByUser: boolean
 	postWithUser: PostWithUser
-}> = ({ isLikedByUser, isForwardedByUser, postWithUser }) => {
-	const [isPostLiked, setPostLiked] = useState<boolean>(isLikedByUser)
-	const [postLikedCount, setPostLikedCount] = useState<number>(postWithUser.post.replaysCount)
-
-	const [isPostForwarded, setPostForwarded] = useState<boolean>(isForwardedByUser)
-	const [postForwardCount, setPostForwardCount] = useState<number>(
-		postWithUser.post.forwardsCount
-	)
-
-	const likePost = api.posts.setPostLiked.useMutation({
-		onSuccess: () => {
-			toast.success("Post Liked!")
-			setPostLiked(true)
-			setPostLikedCount(postLikedCount + 1)
-		},
-		onError: (e) => {
-			const error =
-				ParseZodErrorToString(e.data?.zodError) ??
-				"Failed to like post! Please try again later"
-			toast.error(error, { duration: CONFIG.TOAST_ERROR_DURATION_MS })
-		},
-	})
-
-	const unlikePost = api.posts.setPostUnliked.useMutation({
-		onSuccess: () => {
-			toast.success("Post Unliked!")
-			setPostLiked(false)
-			setPostLikedCount(postLikedCount - 1)
-		},
-		onError: (e) => {
-			const error =
-				ParseZodErrorToString(e.data?.zodError) ??
-				"Failed to unlike post! Please try again later"
-			toast.error(error, { duration: CONFIG.TOAST_ERROR_DURATION_MS })
-		},
-	})
-
-	const forwardPost = api.posts.forwardPost.useMutation({
-		onSuccess: () => {
-			toast.success("Post Forwarded!")
-			setPostForwarded(true)
-			setPostForwardCount(postLikedCount + 1)
-		},
-		onError: (e) => {
-			const error =
-				ParseZodErrorToString(e.data?.zodError) ??
-				"Failed to forward post! Please try again later"
-			toast.error(error, { duration: CONFIG.TOAST_ERROR_DURATION_MS })
-		},
-	})
-
-	const removePostForward = api.posts.removePostForward.useMutation({
-		onSuccess: () => {
-			toast.success("Delete Post Forward!")
-			setPostForwarded(false)
-			setPostForwardCount(postLikedCount - 1)
-		},
-		onError: (e) => {
-			const error =
-				ParseZodErrorToString(e.data?.zodError) ??
-				"Failed to delete forward! Please try again later"
-			toast.error(error, { duration: CONFIG.TOAST_ERROR_DURATION_MS })
-		},
-	})
-
+	forwardAction: (action: "forward" | "deleteForward", postId: string) => void
+	likeAction: (action: "like" | "unlike", postId: string) => void
+}> = ({ isLikedByUser, isForwardedByUser, postWithUser, forwardAction, likeAction }) => {
 	return (
 		<footer className="mt-3 flex text-gray-500">
 			<Link
@@ -103,16 +37,16 @@ export const PostFooter: FC<{
 							className="flex h-full p-3  hover:bg-gray-200"
 							onClick={(e) => {
 								e.stopPropagation()
-								if (isPostForwarded) {
-									removePostForward.mutate(postWithUser.post.id)
+								if (isForwardedByUser) {
+									forwardAction("deleteForward", postWithUser.post.id)
 								} else {
-									forwardPost.mutate(postWithUser.post.id)
+									forwardAction("forward", postWithUser.post.id)
 								}
 							}}
 						>
 							<Icon iconKind="postForward" />
 							<span className="pl-1 font-bold text-black">
-								{isPostForwarded ? "Delete Forward" : "Forward"}
+								{isForwardedByUser ? "Delete Forward" : "Forward"}
 							</span>
 						</li>
 						<li
@@ -127,28 +61,28 @@ export const PostFooter: FC<{
 					</ul>
 				</div>
 				<span className={"self-center pl-1 text-xl group-hover:text-green-400"}>
-					{postForwardCount}
+					{postWithUser.post.forwardsCount}
 				</span>
 			</div>
 			<div
 				className="group flex"
 				onClick={(e) => {
 					e.stopPropagation()
-					if (isPostLiked) {
-						unlikePost.mutate(postWithUser.post.id)
+					if (isLikedByUser) {
+						likeAction("unlike", postWithUser.post.id)
 					} else {
-						likePost.mutate(postWithUser.post.id)
+						likeAction("like", postWithUser.post.id)
 					}
 				}}
 			>
 				<Heart
 					className={`h-9 w-9 rounded-full p-1 ${
-						isPostLiked ? "group-hover:bg-gray-500" : "group-hover:bg-red-500"
+						isLikedByUser ? "group-hover:bg-gray-500" : "group-hover:bg-red-500"
 					}`}
-					fillColor={isPostLiked ? "red" : ""}
+					fillColor={isLikedByUser ? "red" : ""}
 				/>
 				<span className={"self-center pl-1 text-xl group-hover:text-red-500"}>
-					{postLikedCount}
+					{postWithUser.post.likeCount}
 				</span>
 			</div>
 		</footer>

--- a/src/components/postsPage/PostFooter.tsx
+++ b/src/components/postsPage/PostFooter.tsx
@@ -46,7 +46,7 @@ export const PostFooter: FC<{
 	return (
 		<footer className="mt-3 flex text-gray-500">
 			<Link
-				className="group mr-2 flex"
+				className="group mr-4 flex"
 				href={`/post/${postWithUser.author.username}/status/${postWithUser.post.id}`}
 			>
 				<div className={"flex rounded-full p-1 group-hover:bg-blue-400"}>
@@ -56,7 +56,27 @@ export const PostFooter: FC<{
 					{postWithUser.post.replaysCount}
 				</span>
 			</Link>
-
+			<div className="group relative mr-4 flex">
+				<div className={"flex rounded-full p-1 group-hover:bg-green-300"}>
+					<Icon iconKind="postForward" />
+				</div>
+				<div className="hidden group-hover:block">
+					<ul
+						className="absolute top-8 left-0 z-10 w-44 flex-col rounded-lg 
+							bg-white shadow-[0px_0px_3px_1px_#00000024] group-hover:flex"
+					>
+						<li className="flex h-full p-3  hover:bg-gray-200">
+							<Icon iconKind="postForward" />
+							<span className="pl-1 font-bold text-black">Forward</span>
+						</li>
+						<li className="flex h-full p-3  hover:bg-gray-200">
+							<Icon iconKind="quote" />
+							<span className="pl-1 font-bold text-black">Quote</span>
+						</li>
+					</ul>
+				</div>
+				<span className={"self-center pl-1 text-xl group-hover:text-green-400"}>{0}</span>
+			</div>
 			<div
 				className="group flex"
 				onClick={(e) => {

--- a/src/components/postsPage/PostItem.tsx
+++ b/src/components/postsPage/PostItem.tsx
@@ -16,7 +16,15 @@ export const PostItem: FC<{
 	onOptionClick: (action: string, postId: string) => void
 	onNavigateToPost: () => void
 	postLiked: boolean
-}> = ({ postWithUser, onOptionClick, menuItemsType, onNavigateToPost, postLiked }) => {
+	isForwardedByUser: boolean
+}> = ({
+	postWithUser,
+	onOptionClick,
+	menuItemsType,
+	onNavigateToPost,
+	postLiked,
+	isForwardedByUser,
+}) => {
 	return (
 		<li
 			className="cursor-pointer rounded-lg py-2 hover:bg-gray-100"
@@ -46,7 +54,11 @@ export const PostItem: FC<{
 						</span>
 					</div>
 					<span>{postWithUser.post.content}</span>
-					<PostFooter isLikedByUser={postLiked} postWithUser={postWithUser} />
+					<PostFooter
+						isLikedByUser={postLiked}
+						postWithUser={postWithUser}
+						isForwardedByUser={isForwardedByUser}
+					/>
 				</div>
 				{menuItemsType !== "view" && (
 					<div className="group relative flex h-12 w-1/12 justify-center rounded-full hover:bg-gray-200">

--- a/src/components/postsPage/PostItem.tsx
+++ b/src/components/postsPage/PostItem.tsx
@@ -15,15 +15,17 @@ export const PostItem: FC<{
 	menuItemsType: PostMenuItemsType
 	onOptionClick: (action: string, postId: string) => void
 	onNavigateToPost: () => void
-	postLiked: boolean
 	isForwardedByUser: boolean
+	forwardAction: (action: "forward" | "deleteForward", postId: string) => void
+	likeAction: (action: "like" | "unlike", postId: string) => void
 }> = ({
 	postWithUser,
 	onOptionClick,
 	menuItemsType,
 	onNavigateToPost,
-	postLiked,
 	isForwardedByUser,
+	forwardAction,
+	likeAction,
 }) => {
 	return (
 		<li
@@ -55,9 +57,11 @@ export const PostItem: FC<{
 					</div>
 					<span>{postWithUser.post.content}</span>
 					<PostFooter
-						isLikedByUser={postLiked}
+						isLikedByUser={postWithUser.post.isLikedBySignInUser}
 						postWithUser={postWithUser}
 						isForwardedByUser={isForwardedByUser}
+						forwardAction={forwardAction}
+						likeAction={likeAction}
 					/>
 				</div>
 				{menuItemsType !== "view" && (

--- a/src/components/postsPage/PostItem.tsx
+++ b/src/components/postsPage/PostItem.tsx
@@ -15,7 +15,6 @@ export const PostItem: FC<{
 	menuItemsType: PostMenuItemsType
 	onOptionClick: (action: string, postId: string) => void
 	onNavigateToPost: () => void
-	isForwardedByUser: boolean
 	forwardAction: (action: "forward" | "deleteForward", postId: string) => void
 	likeAction: (action: "like" | "unlike", postId: string) => void
 }> = ({
@@ -23,7 +22,6 @@ export const PostItem: FC<{
 	onOptionClick,
 	menuItemsType,
 	onNavigateToPost,
-	isForwardedByUser,
 	forwardAction,
 	likeAction,
 }) => {
@@ -59,7 +57,7 @@ export const PostItem: FC<{
 					<PostFooter
 						isLikedByUser={postWithUser.post.isLikedBySignInUser}
 						postWithUser={postWithUser}
-						isForwardedByUser={isForwardedByUser}
+						isForwardedByUser={postWithUser.post.isForwardedPostBySignInUser}
 						forwardAction={forwardAction}
 						likeAction={likeAction}
 					/>

--- a/src/components/postsPage/types.ts
+++ b/src/components/postsPage/types.ts
@@ -14,4 +14,6 @@ export type Post = PrismaPost & {
 	likeCount: number
 	replaysCount: number
 	forwardsCount: number
+	isLikedBySignInUser: boolean
+	isForwardedPostBySignInUser: boolean
 }

--- a/src/components/postsPage/types.ts
+++ b/src/components/postsPage/types.ts
@@ -13,4 +13,5 @@ export type PostMenuItemsType = "view" | "followedAuthor" | "notFollowedAuthor" 
 export type Post = PrismaPost & {
 	likeCount: number
 	replaysCount: number
+	forwardsCount: number
 }

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -1,6 +1,6 @@
 import { SignIn, useUser } from "@clerk/nextjs"
 import { getAuth } from "@clerk/nextjs/server"
-import { GetServerSidePropsContext, NextPage } from "next"
+import { type GetServerSidePropsContext, type NextPage } from "next"
 import { LoadingPage } from "~/components/LoadingPage"
 
 export const getServerSideProps = (props: GetServerSidePropsContext) => {
@@ -20,7 +20,7 @@ export const getServerSideProps = (props: GetServerSidePropsContext) => {
 	}
 }
 
-const signIn: NextPage = () => {
+const SignInPage: NextPage = () => {
 	const { isLoaded } = useUser()
 
 	if (!isLoaded) {
@@ -41,4 +41,4 @@ const signIn: NextPage = () => {
 	)
 }
 
-export default signIn
+export default SignInPage

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,4 +1,4 @@
-import { SignIn, useUser } from "@clerk/nextjs"
+import { useUser } from "@clerk/nextjs"
 import { type GetServerSidePropsContext, type NextPage } from "next"
 import { Layout } from "~/components/Layout"
 import { LoadingPage } from "~/components/LoadingPage"

--- a/src/pages/post/[username]/status/[postId].tsx
+++ b/src/pages/post/[username]/status/[postId].tsx
@@ -18,6 +18,7 @@ import { useRouter } from "next/router"
 import { usePostMenuItemsType } from "~/hooks/usePostMenuItemsType"
 import { LoadingPage } from "~/components/LoadingPage"
 import { useEffect, useState } from "react"
+
 export const getServerSideProps: GetServerSideProps = async (props) => {
 	const username = props.params?.username as string
 	const postId = props.params?.postId as string
@@ -77,7 +78,7 @@ const ReplayPost: NextPage<{
 			})
 			setReplays(replays)
 		}
-	}, [postReplays.data])
+	}, [postReplays.data, postIdsForwardedByUser])
 
 	const router = useRouter()
 

--- a/src/pages/post/[username]/status/[postId].tsx
+++ b/src/pages/post/[username]/status/[postId].tsx
@@ -91,7 +91,7 @@ const ReplayPost: NextPage<{
 		onError: (e) => {
 			const error =
 				ParseZodErrorToString(e.data?.zodError) ??
-				"Failed to update settings! Please try again later"
+				"Failed to create replay! Please try again later"
 			toast.error(error, { duration: CONFIG.TOAST_ERROR_DURATION_MS })
 		},
 	})

--- a/src/pages/post/[username]/status/[postId].tsx
+++ b/src/pages/post/[username]/status/[postId].tsx
@@ -69,7 +69,6 @@ const ReplayPost: NextPage<{
 
 	useEffect(() => {
 		if (postReplays.data) {
-			console.log("rerender")
 			const replays = postReplays.data.map((post) => {
 				post.post.isForwardedPostBySignInUser = postIdsForwardedByUser.some(
 					(postId) => postId === post.post.id

--- a/src/pages/post/[username]/status/[postId].tsx
+++ b/src/pages/post/[username]/status/[postId].tsx
@@ -77,7 +77,7 @@ const ReplayPost: NextPage<{
 			})
 			setReplays(replays)
 		}
-	}, [setReplays, postReplays.data])
+	}, [postReplays.data])
 
 	const router = useRouter()
 
@@ -112,7 +112,7 @@ const ReplayPost: NextPage<{
 		onSuccess: () => {
 			toast.success("Post Liked!")
 			if (replays) {
-				const copyReplays = replays?.map((replay) => {
+				const copyReplays = replays.map((replay) => {
 					if (replay.post.id === usagePostId) {
 						replay.post.likeCount += 1
 						replay.post.isLikedBySignInUser = true
@@ -135,7 +135,7 @@ const ReplayPost: NextPage<{
 		onSuccess: () => {
 			toast.success("Post Unliked!")
 			if (replays) {
-				const copyReplays = replays?.map((replay) => {
+				const copyReplays = replays.map((replay) => {
 					if (replay.post.id === usagePostId) {
 						replay.post.likeCount -= 1
 						replay.post.isLikedBySignInUser = false
@@ -158,7 +158,7 @@ const ReplayPost: NextPage<{
 		onSuccess: () => {
 			toast.success("Post Forwarded!")
 			if (replays) {
-				const copyReplays = replays?.map((replay) => {
+				const copyReplays = replays.map((replay) => {
 					if (replay.post.id === usagePostId) {
 						replay.post.forwardsCount += 1
 						replay.post.isForwardedPostBySignInUser = true
@@ -181,7 +181,7 @@ const ReplayPost: NextPage<{
 		onSuccess: () => {
 			toast.success("Delete Post Forward!")
 			if (replays) {
-				const copyReplays = replays?.map((replay) => {
+				const copyReplays = replays.map((replay) => {
 					if (replay.post.id === usagePostId) {
 						replay.post.forwardsCount -= 1
 						replay.post.isForwardedPostBySignInUser = false

--- a/src/pages/post/[username]/status/[postId].tsx
+++ b/src/pages/post/[username]/status/[postId].tsx
@@ -56,7 +56,6 @@ export const getServerSideProps: GetServerSideProps = async (props) => {
 }
 
 // todo signInUser, isUserFollowProfile, postsLikedByUser as one object?
-
 const ReplayPost: NextPage<{
 	post: Post
 	author: Profile
@@ -64,6 +63,9 @@ const ReplayPost: NextPage<{
 	isUserFollowProfile: boolean | null
 	postIdsForwardedByUser: string[]
 }> = ({ post, author, signInUser, isUserFollowProfile, postIdsForwardedByUser }) => {
+	const router = useRouter()
+	const type = usePostMenuItemsType(isUserFollowProfile, signInUser, author.id)
+
 	const [replays, setReplays] = useState<PostWithUser[]>()
 	const postReplays = api.posts.getPostReplays.useQuery(post.id)
 
@@ -78,10 +80,6 @@ const ReplayPost: NextPage<{
 			setReplays(replays)
 		}
 	}, [postReplays.data, postIdsForwardedByUser])
-
-	const router = useRouter()
-
-	const type = usePostMenuItemsType(isUserFollowProfile, signInUser, author.id)
 
 	const { mutate, isLoading: isPosting } = api.posts.createReplayPost.useMutation({
 		onSuccess: async () => {
@@ -265,7 +263,6 @@ const ReplayPost: NextPage<{
 								}}
 								menuItemsType={type}
 								onOptionClick={handlePostOptionClick}
-								isForwardedByUser={replay.post.isForwardedPostBySignInUser}
 								forwardAction={(forward, postId) => {
 									if (forward === "deleteForward") {
 										removePostForward.mutate(postId)

--- a/src/pages/post/[username]/status/[postId].tsx
+++ b/src/pages/post/[username]/status/[postId].tsx
@@ -9,7 +9,7 @@ import { PostItem } from "~/components/postsPage/PostItem"
 import type { Post } from "~/components/postsPage/types"
 import type { Profile, SignInUser } from "~/components/profilePage/types"
 import { isFolloweed } from "~/server/api/follow"
-import { getPostById } from "~/server/api/posts"
+import { getPostById, getPostIdsForwardedByUser } from "~/server/api/posts"
 import { getProfileByUserName } from "~/server/api/profile"
 import { api } from "~/utils/api"
 import { ParseZodErrorToString } from "~/utils/helpers"
@@ -34,6 +34,7 @@ export const getServerSideProps: GetServerSideProps = async (props) => {
 	}
 
 	const isUserFollowProfile = userId ? await isFolloweed(userId, author.id) : false
+	const postIdsForwardedByUser = userId ? await getPostIdsForwardedByUser(userId) : []
 
 	const signInUser: SignInUser = {
 		userId: userId ? userId : null,
@@ -46,6 +47,7 @@ export const getServerSideProps: GetServerSideProps = async (props) => {
 			author,
 			signInUser,
 			isUserFollowProfile: isUserFollowProfile ? isUserFollowProfile : null,
+			postIdsForwardedByUser,
 		},
 	}
 }
@@ -57,7 +59,8 @@ const ReplayPost: NextPage<{
 	author: Profile
 	signInUser: SignInUser
 	isUserFollowProfile: boolean | null
-}> = ({ post, author, signInUser, isUserFollowProfile }) => {
+	postIdsForwardedByUser: string[]
+}> = ({ post, author, signInUser, isUserFollowProfile, postIdsForwardedByUser }) => {
 	const postReplays = api.posts.getPostReplays.useQuery(post.id)
 
 	const postsLikedByUser = api.posts.getPostsLikedByUser.useQuery(
@@ -163,6 +166,9 @@ const ReplayPost: NextPage<{
 										  )
 										: false
 								}
+								isForwardedByUser={postIdsForwardedByUser.some(
+									(postId) => postId === replay.post.id
+								)}
 							/>
 						))}
 					</ul>

--- a/src/pages/post/[username]/status/[postId].tsx
+++ b/src/pages/post/[username]/status/[postId].tsx
@@ -65,7 +65,6 @@ const ReplayPost: NextPage<{
 	postIdsForwardedByUser: string[]
 }> = ({ post, author, signInUser, isUserFollowProfile, postIdsForwardedByUser }) => {
 	const [replays, setReplays] = useState<PostWithUser[]>()
-	const [usagePostId, setUsagePostId] = useState<string | null>()
 	const postReplays = api.posts.getPostReplays.useQuery(post.id)
 
 	useEffect(() => {
@@ -110,11 +109,11 @@ const ReplayPost: NextPage<{
 	})
 
 	const likePost = api.posts.setPostLiked.useMutation({
-		onSuccess: () => {
+		onSuccess: (postId: string) => {
 			toast.success("Post Liked!")
 			if (replays) {
 				const copyReplays = replays.map((replay) => {
-					if (replay.post.id === usagePostId) {
+					if (replay.post.id === postId) {
 						replay.post.likeCount += 1
 						replay.post.isLikedBySignInUser = true
 					}
@@ -122,7 +121,6 @@ const ReplayPost: NextPage<{
 				})
 				setReplays(copyReplays)
 			}
-			setUsagePostId(null)
 		},
 		onError: (e) => {
 			const error =
@@ -133,11 +131,11 @@ const ReplayPost: NextPage<{
 	})
 
 	const unlikePost = api.posts.setPostUnliked.useMutation({
-		onSuccess: () => {
+		onSuccess: (postId: string) => {
 			toast.success("Post Unliked!")
 			if (replays) {
 				const copyReplays = replays.map((replay) => {
-					if (replay.post.id === usagePostId) {
+					if (replay.post.id === postId) {
 						replay.post.likeCount -= 1
 						replay.post.isLikedBySignInUser = false
 					}
@@ -145,7 +143,6 @@ const ReplayPost: NextPage<{
 				})
 				setReplays(copyReplays)
 			}
-			setUsagePostId(null)
 		},
 		onError: (e) => {
 			const error =
@@ -156,11 +153,11 @@ const ReplayPost: NextPage<{
 	})
 
 	const forwardPost = api.posts.forwardPost.useMutation({
-		onSuccess: () => {
+		onSuccess: (postId: string) => {
 			toast.success("Post Forwarded!")
 			if (replays) {
 				const copyReplays = replays.map((replay) => {
-					if (replay.post.id === usagePostId) {
+					if (replay.post.id === postId) {
 						replay.post.forwardsCount += 1
 						replay.post.isForwardedPostBySignInUser = true
 					}
@@ -168,7 +165,6 @@ const ReplayPost: NextPage<{
 				})
 				setReplays(copyReplays)
 			}
-			setUsagePostId(null)
 		},
 		onError: (e) => {
 			const error =
@@ -179,11 +175,11 @@ const ReplayPost: NextPage<{
 	})
 
 	const removePostForward = api.posts.removePostForward.useMutation({
-		onSuccess: () => {
+		onSuccess: (postId: string) => {
 			toast.success("Delete Post Forward!")
 			if (replays) {
 				const copyReplays = replays.map((replay) => {
-					if (replay.post.id === usagePostId) {
+					if (replay.post.id === postId) {
 						replay.post.forwardsCount -= 1
 						replay.post.isForwardedPostBySignInUser = false
 					}
@@ -191,7 +187,6 @@ const ReplayPost: NextPage<{
 				})
 				setReplays(copyReplays)
 			}
-			setUsagePostId(null)
 		},
 		onError: (e) => {
 			const error =
@@ -272,7 +267,6 @@ const ReplayPost: NextPage<{
 								onOptionClick={handlePostOptionClick}
 								isForwardedByUser={replay.post.isForwardedPostBySignInUser}
 								forwardAction={(forward, postId) => {
-									setUsagePostId(postId)
 									if (forward === "deleteForward") {
 										removePostForward.mutate(postId)
 									} else {
@@ -280,7 +274,6 @@ const ReplayPost: NextPage<{
 									}
 								}}
 								likeAction={(action, postId) => {
-									setUsagePostId(postId)
 									if (action === "like") {
 										likePost.mutate(postId)
 									} else {

--- a/src/pages/signIn.tsx
+++ b/src/pages/signIn.tsx
@@ -1,0 +1,44 @@
+import { SignIn, useUser } from "@clerk/nextjs"
+import { getAuth } from "@clerk/nextjs/server"
+import { GetServerSidePropsContext, NextPage } from "next"
+import { LoadingPage } from "~/components/LoadingPage"
+
+export const getServerSideProps = (props: GetServerSidePropsContext) => {
+	const { userId } = getAuth(props.req)
+
+	if (userId) {
+		return {
+			redirect: {
+				destination: "/home",
+				permanent: false,
+			},
+		}
+	}
+
+	return {
+		props: {},
+	}
+}
+
+const signIn: NextPage = () => {
+	const { isLoaded } = useUser()
+
+	if (!isLoaded) {
+		return <LoadingPage />
+	}
+
+	return (
+		<div>
+			<SignIn
+				appearance={{
+					elements: {
+						rootBox: "mx-auto",
+					},
+				}}
+				redirectUrl={"/home"}
+			/>
+		</div>
+	)
+}
+
+export default signIn

--- a/src/pages/signIn.tsx
+++ b/src/pages/signIn.tsx
@@ -20,7 +20,7 @@ export const getServerSideProps = (props: GetServerSidePropsContext) => {
 	}
 }
 
-const signIn: NextPage = () => {
+const SignIn: NextPage = () => {
 	const { isLoaded } = useUser()
 
 	if (!isLoaded) {
@@ -41,4 +41,4 @@ const signIn: NextPage = () => {
 	)
 }
 
-export default signIn
+export default SignIn

--- a/src/pages/signIn.tsx
+++ b/src/pages/signIn.tsx
@@ -1,4 +1,4 @@
-import { SignIn, useUser } from "@clerk/nextjs"
+import { SignIn as ClerkSignIn, useUser } from "@clerk/nextjs"
 import { getAuth } from "@clerk/nextjs/server"
 import { type GetServerSidePropsContext, type NextPage } from "next"
 import { LoadingPage } from "~/components/LoadingPage"
@@ -20,7 +20,7 @@ export const getServerSideProps = (props: GetServerSidePropsContext) => {
 	}
 }
 
-const SignInPage: NextPage = () => {
+const signIn: NextPage = () => {
 	const { isLoaded } = useUser()
 
 	if (!isLoaded) {
@@ -29,7 +29,7 @@ const SignInPage: NextPage = () => {
 
 	return (
 		<div>
-			<SignIn
+			<ClerkSignIn
 				appearance={{
 					elements: {
 						rootBox: "mx-auto",
@@ -41,4 +41,4 @@ const SignInPage: NextPage = () => {
 	)
 }
 
-export default SignInPage
+export default signIn

--- a/src/server/api/posts.ts
+++ b/src/server/api/posts.ts
@@ -11,11 +11,13 @@ export const getPostById = async (postId: string) => {
 
 	const getLikeCount = getPostLikeCount(postId)
 	const getReplayCount = getPostReplayCount(postId)
+	const getForwardsCount = getPostForwatdCount(postId)
 
-	const [post, likeCount, replaysCount] = await Promise.all([
+	const [post, likeCount, replaysCount, forwardsCount] = await Promise.all([
 		getPost,
 		getLikeCount,
 		getReplayCount,
+		getForwardsCount,
 	])
 	if (!post) {
 		throw new TRPCError({
@@ -33,6 +35,7 @@ export const getPostById = async (postId: string) => {
 		replayId: post.replayId,
 		likeCount,
 		replaysCount,
+		forwardsCount,
 	} as Post
 }
 
@@ -80,4 +83,27 @@ export const getPostsLikedByUser = async (userId: string, postIds: string[]) => 
 	})
 
 	return posts.map((post) => post.postId)
+}
+
+export const getPostForwatdCount = async (postId: string) => {
+	return await prisma.userPostForward.count({
+		where: {
+			postId,
+		},
+	})
+}
+
+export const getPostIdsForwardedByUser = async (userId: string) => {
+	const result = await prisma.userPostForward.findMany({
+		where: {
+			userId,
+		},
+		select: {
+			postId: true,
+		},
+	})
+	if (result) {
+		return result.map((post) => post.postId)
+	}
+	return []
 }

--- a/src/server/api/routers/posts.ts
+++ b/src/server/api/routers/posts.ts
@@ -194,12 +194,14 @@ export const postsRouter = createTRPCRouter({
 				})
 			}
 
-			return await ctx.prisma.userLikePost.deleteMany({
+			await ctx.prisma.userLikePost.deleteMany({
 				where: {
 					postId: input,
 					userId: ctx.authUserId,
 				},
 			})
+
+			return input
 		}),
 	getPostsLikedByUser: privateProcedure
 		.input(z.string().array().optional())
@@ -302,12 +304,13 @@ export const postsRouter = createTRPCRouter({
 				})
 			}
 
-			return await ctx.prisma.userPostForward.create({
+			const result = await ctx.prisma.userPostForward.create({
 				data: {
 					userId: ctx.authUserId,
 					postId: input,
 				},
 			})
+			return result.postId
 		}),
 	removePostForward: privateProcedure
 		.input(z.string().min(25, { message: "wrong postId" }))
@@ -325,12 +328,14 @@ export const postsRouter = createTRPCRouter({
 				})
 			}
 
-			return await ctx.prisma.userPostForward.deleteMany({
+			await ctx.prisma.userPostForward.deleteMany({
 				where: {
 					postId: input,
 					userId: ctx.authUserId,
 				},
 			})
+
+			return input
 		}),
 	getPostIdsForwardedByUser: privateProcedure.query(async ({ ctx }) => {
 		return getPostIdsForwardedByUser(ctx.authUserId)


### PR DESCRIPTION
## Summary
**note: test i done in MY OWN post, normalny it wont be possible to forward own post!**
Add forwarding post of other user to as "our" post, so every one else that see our profile can se post which is not created by us, but forwarded
so its maybe more like broadcast
Post: (in this screen postReplay)
![post](https://github.com/Radseq/Rattle/assets/3647994/8bac14eb-895a-47f4-991a-d0313b1fa173)
Post hover forward icon:
![post_hover_forward_icon](https://github.com/Radseq/Rattle/assets/3647994/9cf75838-d178-403c-b787-b0b164d4c42e)
icon, count after forward
![forwarded](https://github.com/Radseq/Rattle/assets/3647994/b0bb3899-10aa-4338-b2cd-ba08b9f51e83)
Forwarded post in our home page (forwarded post was form replay):
![post_in_home_page](https://github.com/Radseq/Rattle/assets/3647994/bfb69b58-f672-4877-85e8-54ed918254a7)
