### PR TITLE
fix: Post forward errors found

### DIFF
--- a/src/components/postsPage/FetchPosts.tsx
+++ b/src/components/postsPage/FetchPosts.tsx
@@ -52,7 +52,7 @@ export const FetchPosts: FC<{
 	})
 
 	const likePost = api.posts.setPostLiked.useMutation({
-		onSuccess: (postId: string) => {
+		onSuccess: (_, postId) => {
 			toast.success("Post Liked!")
 			if (posts) {
 				const copyPosts = posts.map((post) => {
@@ -74,7 +74,7 @@ export const FetchPosts: FC<{
 	})
 
 	const unlikePost = api.posts.setPostUnliked.useMutation({
-		onSuccess: (postId: string) => {
+		onSuccess: (_, postId) => {
 			toast.success("Post Unliked!")
 			if (posts) {
 				const copyPosts = posts.map((post) => {
@@ -96,7 +96,7 @@ export const FetchPosts: FC<{
 	})
 
 	const forwardPost = api.posts.forwardPost.useMutation({
-		onSuccess: (postId: string) => {
+		onSuccess: (_, postId) => {
 			toast.success("Post Forwarded!")
 			if (posts) {
 				const copyPosts = posts.map((post) => {
@@ -118,19 +118,9 @@ export const FetchPosts: FC<{
 	})
 
 	const removePostForward = api.posts.removePostForward.useMutation({
-		onSuccess: async (postId: string) => {
+		onSuccess: async () => {
 			toast.success("Delete Post Forward!")
 			await getPosts.refetch()
-			if (posts) {
-				const copyPosts = posts.map((post) => {
-					if (post.post.id === postId) {
-						post.post.forwardsCount -= 1
-						post.post.isForwardedPostBySignInUser = false
-					}
-					return post
-				})
-				setPosts(copyPosts)
-			}
 		},
 		onError: (e) => {
 			const error =

--- a/src/pages/post/[username]/status/[postId].tsx
+++ b/src/pages/post/[username]/status/[postId].tsx
@@ -107,7 +107,7 @@ const ReplayPost: NextPage<{
 	})
 
 	const likePost = api.posts.setPostLiked.useMutation({
-		onSuccess: (postId: string) => {
+		onSuccess: (_, postId) => {
 			toast.success("Post Liked!")
 			if (replays) {
 				const copyReplays = replays.map((replay) => {
@@ -129,7 +129,7 @@ const ReplayPost: NextPage<{
 	})
 
 	const unlikePost = api.posts.setPostUnliked.useMutation({
-		onSuccess: (postId: string) => {
+		onSuccess: (_, postId) => {
 			toast.success("Post Unliked!")
 			if (replays) {
 				const copyReplays = replays.map((replay) => {
@@ -151,7 +151,7 @@ const ReplayPost: NextPage<{
 	})
 
 	const forwardPost = api.posts.forwardPost.useMutation({
-		onSuccess: (postId: string) => {
+		onSuccess: (_, postId) => {
 			toast.success("Post Forwarded!")
 			if (replays) {
 				const copyReplays = replays.map((replay) => {
@@ -173,7 +173,7 @@ const ReplayPost: NextPage<{
 	})
 
 	const removePostForward = api.posts.removePostForward.useMutation({
-		onSuccess: (postId: string) => {
+		onSuccess: (_, postId) => {
 			toast.success("Delete Post Forward!")
 			if (replays) {
 				const copyReplays = replays.map((replay) => {

--- a/src/server/api/posts.ts
+++ b/src/server/api/posts.ts
@@ -107,3 +107,30 @@ export const getPostIdsForwardedByUser = async (userId: string) => {
 	}
 	return []
 }
+
+export const isUserLikedPost = async (userId: string, postId: string): Promise<boolean> => {
+	const alreadyLikePost = await prisma.userLikePost.findFirst({
+		where: {
+			userId,
+			postId,
+		},
+	})
+
+	if (alreadyLikePost) {
+		return true
+	}
+	return false
+}
+
+export const isUserForwardedPost = async (userId: string, postId: string): Promise<boolean> => {
+	const forwardedPost = await prisma.userPostForward.findFirst({
+		where: {
+			userId,
+			postId,
+		},
+	})
+	if (forwardedPost) {
+		return true
+	}
+	return false
+}

--- a/src/server/api/routers/posts.ts
+++ b/src/server/api/routers/posts.ts
@@ -276,6 +276,7 @@ export const postsRouter = createTRPCRouter({
 			const alreadyForwarded = ctx.prisma.userPostForward.findFirst({
 				where: {
 					userId: ctx.authUserId,
+					postId: input,
 				},
 			})
 
@@ -290,19 +291,26 @@ export const postsRouter = createTRPCRouter({
 				alreadyForwarded,
 				postToForward,
 			])
-			// todo uncomment after test
-			// if (isAlreadyForwarded) {
-			// 	throw new TRPCError({
-			// 		code: "INTERNAL_SERVER_ERROR",
-			// 		message: "Can't forward own post!",
-			// 	})
-			// } else
-			if (!getPostToForward) {
+
+			if (isAlreadyForwarded) {
 				throw new TRPCError({
 					code: "INTERNAL_SERVER_ERROR",
 					message: "Post is already forwarded!",
 				})
 			}
+			if (!getPostToForward) {
+				throw new TRPCError({
+					code: "INTERNAL_SERVER_ERROR",
+					message: "Post not exists!",
+				})
+			}
+			// todo uncomment after testing
+			// if (getPostToForward.authorId === ctx.authUserId) {
+			// 	throw new TRPCError({
+			// 		code: "INTERNAL_SERVER_ERROR",
+			// 		message: "Can't forward own post!",
+			// 	})
+			// }
 
 			const result = await ctx.prisma.userPostForward.create({
 				data: {

--- a/src/server/api/routers/posts.ts
+++ b/src/server/api/routers/posts.ts
@@ -5,7 +5,13 @@ import { CreateRateLimit } from "~/RateLimit"
 import { CONFIG } from "~/config"
 import { createTRPCRouter, privateProcedure, publicProcedure } from "~/server/api/trpc"
 import { filterClarkClientToUser } from "~/utils/helpers"
-import { getPostById, getPostIdsForwardedByUser, getPostsLikedByUser } from "../posts"
+import {
+	getPostById,
+	getPostIdsForwardedByUser,
+	getPostsLikedByUser,
+	isUserForwardedPost,
+	isUserLikedPost,
+} from "../posts"
 
 const postRateLimit = CreateRateLimit({ requestCount: 1, requestCountPer: "1 m" })
 
@@ -156,12 +162,7 @@ export const postsRouter = createTRPCRouter({
 	setPostLiked: privateProcedure
 		.input(z.string().min(25, { message: "wrong postId" }))
 		.mutation(async ({ ctx, input }) => {
-			const alreadyLikePost = await ctx.prisma.userLikePost.findFirst({
-				where: {
-					userId: ctx.authUserId,
-					postId: input,
-				},
-			})
+			const alreadyLikePost = await isUserLikedPost(ctx.authUserId, input)
 
 			if (alreadyLikePost) {
 				throw new TRPCError({
@@ -181,11 +182,7 @@ export const postsRouter = createTRPCRouter({
 	setPostUnliked: privateProcedure
 		.input(z.string().min(25, { message: "wrong postId" }))
 		.mutation(async ({ ctx, input }) => {
-			const alreadyLikePost = await ctx.prisma.userLikePost.findFirst({
-				where: {
-					userId: ctx.authUserId,
-				},
-			})
+			const alreadyLikePost = await isUserLikedPost(ctx.authUserId, input)
 
 			if (!alreadyLikePost) {
 				throw new TRPCError({
@@ -273,12 +270,7 @@ export const postsRouter = createTRPCRouter({
 	forwardPost: privateProcedure
 		.input(z.string().min(25, { message: "wrong postId" }))
 		.mutation(async ({ ctx, input }) => {
-			const alreadyForwarded = ctx.prisma.userPostForward.findFirst({
-				where: {
-					userId: ctx.authUserId,
-					postId: input,
-				},
-			})
+			const forwardedPostByUser = isUserForwardedPost(ctx.authUserId, input)
 
 			const postToForward = ctx.prisma.post.findFirst({
 				where: {
@@ -288,7 +280,7 @@ export const postsRouter = createTRPCRouter({
 			})
 
 			const [isAlreadyForwarded, getPostToForward] = await Promise.all([
-				alreadyForwarded,
+				forwardedPostByUser,
 				postToForward,
 			])
 
@@ -323,11 +315,7 @@ export const postsRouter = createTRPCRouter({
 	removePostForward: privateProcedure
 		.input(z.string().min(25, { message: "wrong postId" }))
 		.mutation(async ({ ctx, input }) => {
-			const forwardedPost = await ctx.prisma.userPostForward.findFirst({
-				where: {
-					userId: ctx.authUserId,
-				},
-			})
+			const forwardedPost = await isUserForwardedPost(ctx.authUserId, input)
 
 			if (!forwardedPost) {
 				throw new TRPCError({


### PR DESCRIPTION
## Summary
Remove repeated code.
Use on trpc mutation success variable instead returning data.
Error handle in forward post trpc procedure.